### PR TITLE
Fixed property name for URL field

### DIFF
--- a/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
+++ b/obs-websocket-dotnet/Types/BrowserSourceProperties.cs
@@ -17,7 +17,7 @@ namespace OBSWebsocketDotNet.Types
         /// <summary>
         /// URL to load in the embedded browser
         /// </summary>
-        [JsonProperty(PropertyName = "fps")]
+        [JsonProperty(PropertyName = "url")]
         public string URL;
 
         /// <summary>


### PR DESCRIPTION
Leaving the invalid property name caused an exception when calling GetBrowserSourceProperties